### PR TITLE
Update oval_org.mitre.oval_tst_79894.xml

### DIFF
--- a/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79894.xml
+++ b/repository/tests/windows/file_test/79000/oval_org.mitre.oval_tst_79894.xml
@@ -1,4 +1,4 @@
 <file_test xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#windows" check="at least one" check_existence="at_least_one_exists" comment="the version of Ogl.dll is less than 14.0.6117.5001" id="oval:org.mitre.oval:tst:79894" version="1">
-  <object object_ref="oval:org.mitre.oval:obj:6428" />
+  <object object_ref="oval:org.mitre.oval:obj:24602" />
   <state state_ref="oval:org.mitre.oval:ste:19672" />
 </file_test>


### PR DESCRIPTION
This test (oval:org.mitre.oval:tst:79894) must check Office 2010 (oval:org.mitre.oval:obj:24602) instead of Office 2007 (oval:org.mitre.oval:obj:6428).

This test use in "Microsoft Office 2010" cases. For example (oval:org.mitre.oval:def:15388):

   <criteria operator="AND" comment="Microsoft Office 2010 (KB2589337)">
          <extend_definition comment="Microsoft Office 2010 is installed" definition_ref="oval:org.mitre.oval:def:12061" />
          <criterion comment="the version of Ogl.dll is less than 14.0.6117.5001" test_ref="oval:org.mitre.oval:tst:79894" />
    </criteria>